### PR TITLE
Change url to be closer to eLife article URL structure

### DIFF
--- a/articles/30274/index.html
+++ b/articles/30274/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Replication Study: Transcriptional amplification in tumor cells with elevated c-Myc</title>
-    <link rel="stylesheet" type="text/css" href="./reset.css">
-    <link rel="stylesheet" type="text/css" href="./stencila.css">
-    <link rel="stylesheet" type="text/css" href="./elife-assets/all.26901bd1.css">
+    <link rel="stylesheet" type="text/css" href="../../reset.css">
+    <link rel="stylesheet" type="text/css" href="../../stencila.css">
+    <link rel="stylesheet" type="text/css" href="../../elife-assets/all.26901bd1.css">
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -13,16 +13,16 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KK28B4B');</script>
     <!-- End Google Tag Manager -->
-    <script type="text/javascript" src="./katex/katex.min.js"></script>
-    <script type="text/javascript" src="./lib/plotly.min.js"></script>
-    <script type="text/javascript" src="./lib/substance.js"></script>
-    <script type="text/javascript" src="./lib/texture.js"></script>
-    <script type="text/javascript" src="./lib/stencila-mini.js"></script>
-    <script type="text/javascript" src="./lib/stencila-envcore.min.js"></script>
-    <script type="text/javascript" src="./lib/stencila-libcore.min.js"></script>
-    <script type="text/javascript" src="./stencila.js"></script>
+    <script type="text/javascript" src="../../katex/katex.min.js"></script>
+    <script type="text/javascript" src="../../lib/plotly.min.js"></script>
+    <script type="text/javascript" src="../../lib/substance.js"></script>
+    <script type="text/javascript" src="../../lib/texture.js"></script>
+    <script type="text/javascript" src="../../lib/stencila-mini.js"></script>
+    <script type="text/javascript" src="../../lib/stencila-envcore.min.js"></script>
+    <script type="text/javascript" src="../../lib/stencila-libcore.min.js"></script>
+    <script type="text/javascript" src="../../stencila.js"></script>
     <!-- vfs.js can be removed as soon as storage urls are used -->
-    <script type="text/javascript" src="./vfs.js"></script>
+    <script type="text/javascript" src="../../vfs.js"></script>
     <style>
 
       /* Selector matches a Stencilla-generated element */
@@ -41,7 +41,7 @@
 
     </style>
 
-    <link rel="stylesheet" href="./elife-assets/overrides.css">
+    <link rel="stylesheet" href="../../elife-assets/overrides.css">
     <script>
       window.STENCILA_HOSTS="https://bindilla.stenci.la/https://github.com/stencila/examples/elife-30274-binder/v0";
       window.addEventListener('load', () => {
@@ -71,8 +71,8 @@
           </div>
           <a href="https://elifesciences.org/" class="site-header__logo_link">
             <picture class="site-header__logo_link_image">
-              <source srcset="./elife-assets/elife-logo-full.b1283c9a.svg" type="image/svg+xml" media="(min-width: 45.625em)">
-              <source srcset="./elife-assets/elife-logo-symbol.6f18db13.svg" type="image/svg+xml">
+              <source srcset="../../elife-assets/elife-logo-full.b1283c9a.svg" type="image/svg+xml" media="(min-width: 45.625em)">
+              <source srcset="../../elife-assets/elife-logo-symbol.6f18db13.svg" type="image/svg+xml">
               <img src="./elife-assets/elife-logo-full-1x.ce3f6342.png" alt="eLife logo" class="site-header__logo_link">
             </picture>
             <span class="visuallyhidden">eLife home page</span>
@@ -180,11 +180,11 @@
 
 
 
-                    <source srcset="./elife-assets/nav-primary-search-ic.350bcf38.svg" type="image/svg+xml">
+                    <source srcset="../../elife-assets/nav-primary-search-ic.350bcf38.svg" type="image/svg+xml">
 
 
 
-                    <img srcset="./elife-assets/nav-primary-search-ic.350bcf38.svg" alt="">
+                    <img srcset="../../elife-assets/nav-primary-search-ic.350bcf38.svg" alt="">
 
 
                   </picture>

--- a/example.html
+++ b/example.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting to /articles/30274</title>
+  <meta http-equiv="refresh" content="0; URL='https://repro.elifesciences.org/articles/30274" />
+</head>
+<body>
+
+</body>
+</html>

--- a/example.html
+++ b/example.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Redirecting to /articles/30274</title>
-  <meta http-equiv="refresh" content="0; URL='https://repro.elifesciences.org/articles/30274" />
+  <meta http-equiv="refresh" content="0; URL='/articles/30274" />
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -37,42 +37,42 @@
     </div>
     <div class="examples">
       <p>
-        <a href="./example.html?archive=introduction"><b>Introduction to Stencila</b></a>:
+        <a href="articles/30274/index.html?archive=introduction"><b>Introduction to Stencila</b></a>:
         Stencila's getting started guide.
       </p>
       <p>
-        <a href="./example.html?archive=introduction-rds"><b>Introduction to Reproducible Document Stack</b></a>:
+        <a href="articles/30274/index.html?archive=introduction-rds"><b>Introduction to Reproducible Document Stack</b></a>:
         Stencila's getting started guide.
       </p>
       <p>
-        <a href="./example.html?archive=repro-pub"><b>Reproducible Publication</b></a>:
+        <a href="articles/30274/index.html?archive=repro-pub"><b>Reproducible Publication</b></a>:
         a project demonstrating the use of a reproducible article + sheet for data.
       </p>
       <p>
-        <a href="./example.html?archive=kitchen-sink"><b>Kitchen sink</b></a>:
+        <a href="articles/30274/index.html?archive=kitchen-sink"><b>Kitchen sink</b></a>:
         a project with everything in it for testing.
       </p>
       <p>
-        <a href="./example.html?archive=blank"><b>Blank</b></a>:
+        <a href="articles/30274/index.html?archive=blank"><b>Blank</b></a>:
         blank text and spreadsheet documents, mainly for testing.
       </p>
       <p>
-        <a href="./example.html?archive=mini"><b>Mini</b></a>:
+        <a href="articles/30274/index.html?archive=mini"><b>Mini</b></a>:
         text and spreadsheet documents with some code cells written in Mini, Stencila's simple embedded language.
       </p>
       <p>
-        <a href="./example.html?archive=plotly"><b>Plotly</b></a>: example using <code>plotly</code> function for plotting.
+        <a href="articles/30274/index.html?archive=plotly"><b>Plotly</b></a>: example using <code>plotly</code> function for plotting.
       </p>
       <p>
-        <a href="./example.html?archive=r-sheet"><b>R spreadsheet</b></a>:
+        <a href="articles/30274/index.html?archive=r-sheet"><b>R spreadsheet</b></a>:
         a sheet with R code in it's cells
       </p>
       <p>
-        <a href="./example.html?archive=py-jupyter"><b>Jupyter Notebook</b></a>:
+        <a href="articles/30274/index.html?archive=py-jupyter"><b>Jupyter Notebook</b></a>:
         an example of a Jupyter notebook convetered into a Stencila project
       </p>
       <p>
-        <a href="./example.html?archive=r-markdown"><b>R Markdown</b></a>:
+        <a href="articles/30274/index.html?archive=r-markdown"><b>R Markdown</b></a>:
         an example of a R Markdown document convetered into a Stencila project
       </p>
     </div>


### PR DESCRIPTION
- Makes the example article available at the path `/articles/30274`
- Redirects old path `/example.html` to new path `/articles/30274` 

Hopefully the redirect can be handled by CDN infrastructure or similar, the redirect in this repo is just a backstop in case that doesn't work (this client side approach is not a good way to handle redirects).